### PR TITLE
Move build status markdown to new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# welcome-ios [![Build Status](https://travis-ci.org/feedhenry-templates/welcome-ios.png)](https://travis-ci.org/feedhenry-templates/welcome-ios)
+# welcome-ios 
+[![Build Status](https://travis-ci.org/feedhenry-templates/welcome-ios.png)](https://travis-ci.org/feedhenry-templates/welcome-ios)
 
 > Swift version is available [here](https://github.com/feedhenry-templates/welcome-ios-swift).
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3422

Motivation: Studio cannot convert the markdown if it's on the same line as the header